### PR TITLE
Fix conflict with other jQuery scripts

### DIFF
--- a/Musicbrainz_acoustid.user.js
+++ b/Musicbrainz_acoustid.user.js
@@ -1,18 +1,19 @@
 // ==UserScript==
 // @name          Musicbrainz: Compare AcoustIDs easier!
-// @version       2020.9.12
+// @version       2021.2.25
 // @description   Displays AcoustID fingerprints in more places at MusicBrainz.
 // @grant         none
 // @downloadURL   https://github.com/otringal/MB-userscripts/raw/master/Musicbrainz_acoustid.user.js
 // @updateURL     https://github.com/otringal/MB-userscripts/raw/master/Musicbrainz_acoustid.user.js
-// @include       *://*musicbrainz.org/artist/*/recordings*
-// @include       *://*musicbrainz.org/artist/*/*edits
-// @include       *://*musicbrainz.org/edit/*
-// @include       *://*musicbrainz.org/recording/merge*
-// @include       *://*musicbrainz.org/release/*
-// @include       *://*musicbrainz.org/search/*
-// @include       *://*musicbrainz.org/user/*/edits/*
-// @require       https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js
+// @match         *://*.musicbrainz.org/artist/*/recordings*
+// @match         *://*.musicbrainz.org/artist/*/*edits
+// @match         *://*.musicbrainz.org/edit/*
+// @match         *://*.musicbrainz.org/recording/merge*
+// @match         *://*.musicbrainz.org/release/*
+// @match         *://*.musicbrainz.org/search/*
+// @match         *://*.musicbrainz.org/user/*/edits/*
+// @exclude       *musicbrainz.org/release/*/edit
+// @exclude       *musicbrainz.org/release/*/edit-relationships
 // @run-at        document-end
 // ==/UserScript==
 //

--- a/Musicbrainz_list destroyer.user.js
+++ b/Musicbrainz_list destroyer.user.js
@@ -1,15 +1,16 @@
 // ==UserScript==
 // @name          Musicbrainz: Ultimate list destroyer
-// @version       2019.10.18
+// @version       2021.2.25
 // @description   Hide/show very long work and/or country lists
 // @namespace     https://github.com/otringal/MB-userscripts
 // @grant         none
-// @require       http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js
-// @include       *://*musicbrainz.org/artist/*/works*
-// @include       *://*musicbrainz.org/release/*
-// @include       *://*musicbrainz.org/release-group/*
-// @include       *://*musicbrainz.org/artist/*/releases*
-// @include       *://*musicbrainz.org/label/*
+// @match         *://*.musicbrainz.org/artist/*/works*
+// @match         *://*.musicbrainz.org/release/*
+// @match         *://*.musicbrainz.org/release-group/*
+// @match         *://*.musicbrainz.org/artist/*/releases*
+// @match         *://*.musicbrainz.org/label/*
+// @exclude       *musicbrainz.org/release/*/edit
+// @exclude       *musicbrainz.org/release/*/edit-relationships
 // @run-at        document-end
 // ==/UserScript==
 //


### PR DESCRIPTION
Remove hardcoded jQuery library require to use MBS own jQuery.
Otherwise, this old version conflicted with some other scripts
including: @kellnerd bookmarklets guessUnicodePunctuation.js (that could
not trigger `change` events).

Replace `include` by `match`.
Regex icludes and matches provide safer schemes.

Exclude some irrelevant pages like release and relationship editor.

Also it seems that `Musicbrainz_list destroyer.user.js` is now unneeded.
Thanks to MBS progress.